### PR TITLE
fix: throw error when the length of the prefix [-p] is greater than 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Goyacc is a version of yacc generating Go programs.
 
 Installation
 
-    $ go get github.com/cznic/goyacc
+    $ # go get github.com/cznic/goyacc
+
+    $ go get github.com/hsrx/goyacc
 
 Documentation: [godoc.org/github.com/cznic/goyacc](http://godoc.org/github.com/cznic/goyacc)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Installation
 
     $ # go get github.com/cznic/goyacc
 
-    $ go get github.com/hsrx/goyacc
+    $ go get github.com/qsmx/goyacc
 
 Documentation: [godoc.org/github.com/cznic/goyacc](http://godoc.org/github.com/cznic/goyacc)

--- a/main.go
+++ b/main.go
@@ -372,6 +372,7 @@ type %[1]sXError struct {
 	}
 	sort.Strings(a)
 	f.Format("\nconst (%i\n")
+	maxTokName += len(*oPref)
 	for _, v := range a {
 		nm := v
 		switch nm {


### PR DESCRIPTION
`
goyacc -p Calc calc.y
`

error
`
panic: strings: negative Repeat count

goroutine 1 [running]:
strings.Repeat(0x1175d50, 0x1, 0xfffffffffffffffe, 0x1176553, 0x7)
	/usr/local/Cellar/go/1.10.1/libexec/src/strings/strings.go:538 +0x1c7
main.main1(0x7ffeefbffafe, 0x3, 0x0, 0x0)
	.../go/src/f/x.go:386 +0xfdf
main.main()
	.../go/src/f/x.go:181 +0x79
`